### PR TITLE
Introduce Repository & Context classes

### DIFF
--- a/Contexts/Context.php
+++ b/Contexts/Context.php
@@ -1,0 +1,39 @@
+<?php
+namespace OmisePlugin\Contexts;
+
+use Exception;
+
+class Context
+{
+    /**
+     * A registered context list.
+     *
+     * @var array
+     */
+    protected $registered_contexts = array();
+
+    /**
+     * A concrete context class.
+     *
+     * @var OmisePlugin\Contexts\ContextInterface
+     */
+    protected $context;
+
+    /**
+     * Read an object context.
+     *
+     * @param  \OmiseApiResource $object
+     *
+     * @return string
+     *
+     * @throws \Exception if context not found.
+     */
+    public function read($object)
+    {
+        if (isset($this->registered_contexts[get_class($object)])) {
+            return $this->registered_contexts[get_class($object)];
+        }
+
+        throw new Exception(get_class($object) . " context not found");
+    }
+}

--- a/Repository.php
+++ b/Repository.php
@@ -11,9 +11,7 @@ class Repository
     protected $context;
 
     /**
-     * @var \OmiseApiResource
-     *
-     * @see http://github.com/omise/omise-php/blob/master/lib/omise/res/OmiseApiResource.php
+     * @var object
      */
     protected $object;
 
@@ -25,5 +23,17 @@ class Repository
     {
         $this->context = $context->read($object);
         $this->object  = $object;
+    }
+
+    /**
+     * Initiate Repository instance.
+     *
+     * @param  object $object
+     *
+     * @return \OmisePlugin\Repository
+     */
+    public static function create($object)
+    {
+        return new self(new Context, $object);
     }
 }

--- a/Repository.php
+++ b/Repository.php
@@ -1,0 +1,29 @@
+<?php
+namespace OmisePlugin;
+
+use OmisePlugin\Contexts\Context;
+
+class Repository
+{
+    /**
+     * @var \OmisePlugin\Contexts\Context
+     */
+    protected $context;
+
+    /**
+     * @var \OmiseApiResource
+     *
+     * @see http://github.com/omise/omise-php/blob/master/lib/omise/res/OmiseApiResource.php
+     */
+    protected $object;
+
+    /**
+     * @param \OmisePlugin\Contexts\Context $context
+     * @param \OmiseApiResource             $object
+     */
+    public function __construct($context, $object)
+    {
+        $this->context = $context->read($object);
+        $this->object  = $object;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,12 @@
         "omise/omise-php": "2.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.*"
+        "phpunit/phpunit": "5.7.*",
+        "mockery/mockery": "0.9.*"
     },
-    "autoload": { }
+    "autoload": {
+        "psr-4": {
+            "OmisePlugin\\": "."
+        }
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f840d9af802caceea7224dd1ae1fb48e",
-    "content-hash": "1a4b1da7584e51f51d096c63858496c3",
+    "hash": "37c13e511a75a8b996bbd39967f1faed",
+    "content-hash": "c566b1d22dbfb13fd95a64f8a13f07c3",
     "packages": [
         {
             "name": "omise/omise-php",
@@ -107,6 +107,116 @@
                 "instantiate"
             ],
             "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/b37020aa976fa52d3de9aa904aa2522dc518f79c",
+                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ],
+                "files": [
+                    "hamcrest/Hamcrest.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2015-05-11 14:41:42"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "0.9.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/mockery.git",
+                "reference": "4de7969f4664da3cef1ccd83866c9f59378c3371"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/4de7969f4664da3cef1ccd83866c9f59378c3371",
+                "reference": "4de7969f4664da3cef1ccd83866c9f59378c3371",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~1.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
+            "homepage": "http://github.com/padraic/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2016-12-19 14:50:55"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1259,16 +1369,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.1",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a7095af4b97a0955f85c8989106c249fa649011f"
+                "reference": "50eadbd7926e31842893c957eca362b21592a97d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7095af4b97a0955f85c8989106c249fa649011f",
-                "reference": "a7095af4b97a0955f85c8989106c249fa649011f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/50eadbd7926e31842893c957eca362b21592a97d",
+                "reference": "50eadbd7926e31842893c957eca362b21592a97d",
                 "shasum": ""
             },
             "require": {
@@ -1310,7 +1420,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-10 10:07:06"
+            "time": "2017-01-03 13:51:32"
         },
         {
             "name": "webmozart/assert",

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -1,0 +1,24 @@
+<?php
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use stdClass as stdClass;
+use OmisePlugin\Repository;
+use OmisePlugin\Contexts\Context;
+
+class RepositoryTest extends MockeryTestCase
+{
+    /**
+     * @test
+     */
+    public function init_new_instance()
+    {
+        // Initialisation.
+        $context    = Mockery::mock(Context::class);
+        $object     = Mockery::mock(stdClass::class);
+
+        // Assertion.
+        $context->shouldReceive('read')
+            ->once()
+            ->andReturn('OmisePlugin\\Contexts\\OmiseChargeContext');
+        $this->assertEquals(Repository::class, get_class(new Repository($context, $object)));
+    }
+}

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+use Exception as Exception;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use stdClass as stdClass;
 use OmisePlugin\Repository;
@@ -12,13 +13,27 @@ class RepositoryTest extends MockeryTestCase
     public function init_new_instance()
     {
         // Initialisation.
-        $context    = Mockery::mock(Context::class);
-        $object     = Mockery::mock(stdClass::class);
+        $context = Mockery::mock(Context::class);
+        $object  = Mockery::mock(stdClass::class);
 
         // Assertion.
         $context->shouldReceive('read')
             ->once()
             ->andReturn('OmisePlugin\\Contexts\\OmiseChargeContext');
         $this->assertEquals(Repository::class, get_class(new Repository($context, $object)));
+    }
+
+    /**
+     * @test
+     * @expectedException        Exception
+     * @expectedExceptionMessage Mockery_1_stdClass context not found
+     */
+    public function context_reader_cannot_read_the_context_from_an_object()
+    {
+        // Initialisation.
+        $object = Mockery::mock(stdClass::class);
+
+        // Assertion.
+        Repository::create($object);
     }
 }


### PR DESCRIPTION
### 1. 💬 Objective

To provide an interface `OmisePlugin\Repository::create()`.
So, my plan is, to make this class support a below use case.
```php
$charge = OmiseCharge::retrieve('id');
$charge = OmisePlugin\Repository::create($charge);

if ($charge->isPaid())
{
    // Do something.
}
```

...

### 2. ⚙ What does the changes do? 

To create new repository, execute `OmisePlugin\Repository::create(OmiseCharge::retrieve())`.

...

### 3. 🛡 Quality Assurance 

Read **RepositoryTest**.
1. `init_new_instance`
1. `context_reader_cannot_read_the_context_from_an_object`

...

### 4. 📝 Additional notes 

This PR just provided an interface, `OmisePlugin\Repository::create()`.
Still didn't implement real `Context` yet.