### PR TITLE
Make repository can access $_values array of an OmiseObject

### DIFF
--- a/Repository.php
+++ b/Repository.php
@@ -1,9 +1,10 @@
 <?php
 namespace OmisePlugin;
 
+use ArrayAccess;
 use OmisePlugin\Contexts\Context;
 
-class Repository
+class Repository implements ArrayAccess
 {
     /**
      * @var \OmisePlugin\Contexts\Context
@@ -71,6 +72,46 @@ class Repository
     public function attachContextByName($name)
     {
         $this->context->readFromName($name);
+    }
+
+    /**
+     * Implementation from the ArrayAccess interface.
+     *
+     * @see http://php.net/manual/en/arrayaccess.offsetexists.php
+     */
+    public function offsetExists($key)
+    {
+        return isset($this->object[$key]);
+    }
+
+    /**
+     * Implementation from the ArrayAccess interface.
+     *
+     * @see http://php.net/manual/en/arrayaccess.offsetget.php
+     */
+    public function offsetGet($key)
+    {
+        return isset($this->object[$key]) ? $this->object[$key] : null;
+    }
+
+    /**
+     * Implementation from the ArrayAccess interface.
+     *
+     * @see http://php.net/manual/en/arrayaccess.offsetset.php
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->object[$key] = $value;
+    }
+
+    /**
+     * Implementation from the ArrayAccess interface.
+     *
+     * @see http://php.net/manual/en/arrayaccess.offsetunset.php
+     */
+    public function offsetUnset($key)
+    {
+        unset($this->object[$key]);
     }
 
     /**


### PR DESCRIPTION
### 1. 💬 Objective

Normally we access Omise value via `$object['key'];`.

This PR aimed to make `Repository` be able to access the object's array.

i.e.
```php
// Current
$charge = OmiseCharge::retrieve('id');
echo $charge['id']; // chrg_xxx

// After assign to repository
$charge = OmiseCharge::retrieve('id');
$charge_repo = OmisePlugin\Repository::add($charge);

echo $charge_repo['id']; // chrg_xxx
```

...

### 2. ⚙ What does the changes do? 

Implement `ArrayAccess` interface.
ref. http://php.net/manual/en/class.arrayaccess.php

...

### 3. 🛡 Quality Assurance 

Test

```php
// Current
$charge = OmiseCharge::retrieve('id');
echo $charge['id']; // chrg_xxx

// After assign to repository
$charge = OmiseCharge::retrieve('id');
$charge_repo = OmisePlugin\Repository::add($charge);

echo $charge_repo['id']; // chrg_xxx
```

`$charge['id']` & `$charge_repo['id']` must give the same value.

...

### 4. 📝 Additional notes 

Nope.