### PR TITLE
Enhance OmiseChargeContext by adding more functions.

### DIFF
--- a/Contexts/OmiseChargeContext.php
+++ b/Contexts/OmiseChargeContext.php
@@ -80,6 +80,11 @@ class OmiseChargeContext
         return false;
     }
 
+    /**
+     * @param  array $params
+     *
+     * @return \OmiseCharge
+     */
     public function create($params)
     {
         $charge = \OmiseCharge::create($params);

--- a/Contexts/OmiseChargeContext.php
+++ b/Contexts/OmiseChargeContext.php
@@ -50,28 +50,6 @@ class OmiseChargeContext
 
     /**
      * @param  \OmiseCharge $charge
-     * @param  callable     $success_callback
-     * @param  callable     $fail_callback
-     *
-     * @return mixed
-     */
-    public function validateAfter3DSecureProcess($charge, $success_callback = null, $fail_callback = null)
-    {
-        if (($charge['capture'] && $this->isPaid($charge))
-            || (! $charge['capture'] && $this->isAuthorized($charge))
-        ) {
-            if (is_callable($success_callback)) return $success_callback($charge);
-
-            return true;
-        }
-
-        if (is_callable($fail_callback)) return $fail_callback($charge);
-
-        return false;
-    }
-
-    /**
-     * @param  \OmiseCharge $charge
      *
      * @return bool
      */
@@ -88,6 +66,28 @@ class OmiseChargeContext
         ) {
             return true;
         }
+
+        return false;
+    }
+
+    /**
+     * @param  \OmiseCharge $charge
+     * @param  callable     $success_callback
+     * @param  callable     $fail_callback
+     *
+     * @return mixed
+     */
+    public function validateAfter3DSecureProcess($charge, $success_callback = null, $fail_callback = null)
+    {
+        if (($charge['capture'] && $this->isPaid($charge))
+            || (! $charge['capture'] && $this->isAuthorized($charge))
+        ) {
+            if (is_callable($success_callback)) return $success_callback($charge);
+
+            return true;
+        }
+
+        if (is_callable($fail_callback)) return $fail_callback($charge);
 
         return false;
     }

--- a/Contexts/OmiseChargeContext.php
+++ b/Contexts/OmiseChargeContext.php
@@ -7,6 +7,18 @@ namespace OmisePlugin\Contexts;
 class OmiseChargeContext
 {
     /**
+     * @param  array $params
+     *
+     * @return \OmiseCharge
+     */
+    public function create($params)
+    {
+        $charge = \OmiseCharge::create($params);
+
+        return $charge;
+    }
+
+    /**
      * @param  \OmiseCharge $charge
      *
      * @return bool
@@ -78,17 +90,5 @@ class OmiseChargeContext
         }
 
         return false;
-    }
-
-    /**
-     * @param  array $params
-     *
-     * @return \OmiseCharge
-     */
-    public function create($params)
-    {
-        $charge = \OmiseCharge::create($params);
-
-        return $charge;
     }
 }

--- a/Contexts/OmiseChargeContext.php
+++ b/Contexts/OmiseChargeContext.php
@@ -1,14 +1,15 @@
 <?php
 namespace OmisePlugin\Contexts;
 
+/**
+ * @see https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php;
+ */
 class OmiseChargeContext
 {
     /**
      * @param  \OmiseCharge $charge
      *
      * @return bool
-     *
-     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php;
      */
     public function isAuthorized($charge)
     {
@@ -23,14 +24,56 @@ class OmiseChargeContext
      * @param  \OmiseCharge $charge
      *
      * @return bool
-     *
-     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php;
      */
     public function isPaid($charge)
     {
         $paid = isset($charge['paid']) ? $charge['paid'] : $charge['captured'];
 
         if ($charge['authorized'] && $paid) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  \OmiseCharge $charge
+     * @param  callable     $success_callback
+     * @param  callable     $fail_callback
+     *
+     * @return mixed
+     */
+    public function validateAfter3DSecureProcess($charge, $success_callback = null, $fail_callback = null)
+    {
+        if (($charge['capture'] && $this->isPaid($charge))
+            || (! $charge['capture'] && $this->isAuthorized($charge))
+        ) {
+            if (is_callable($success_callback)) return $success_callback($charge);
+
+            return true;
+        }
+
+        if (is_callable($fail_callback)) return $fail_callback($charge);
+
+        return false;
+    }
+
+    /**
+     * @param  \OmiseCharge $charge
+     *
+     * @return bool
+     */
+    public function need3DSecureProcess($charge)
+    {
+        $paid = isset($charge['paid']) ? $charge['paid'] : $charge['captured'];
+
+        if ($charge['status'] === 'pending'
+            && ! $charge['authorized']
+            && ! $paid
+            && $charge['source_of_fund'] === 'card'
+            && isset($charge['authorize_uri'])
+            && $charge['authorize_uri'] != null
+        ) {
             return true;
         }
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Plugin for [Omise-PHP](http://github.com/omise/omise-php)
     **example**
 
     ```php
+    $params = array(
+        'amount' => 10000,
+        'card' => 'tokn_test_generated_by_omise',
+        'currency' => 'thb'
+    );
     $charge = \OmisePlugin\Repository::create('OmiseCharge', $params);
 
     if ($charge->isPaid()) {
@@ -34,7 +39,7 @@ Plugin for [Omise-PHP](http://github.com/omise/omise-php)
     **example**
 
     ```php
-    $charge = OmiseCharge::retrieve('chrg_id');
+    $charge = \OmiseCharge::retrieve('chrg_id');
     $charge = \OmisePlugin\Repository::add($charge);
 
     if ($charge->isAuthorized()) {
@@ -44,17 +49,46 @@ Plugin for [Omise-PHP](http://github.com/omise/omise-php)
     }
     ```
 
-  - **isPaid()**
+  - **need3DSecureProcess()**
 
     **example**
 
     ```php
+    $params = array(
+        'amount' => 10000,
+        'card' => 'tokn_test_generated_by_omise',
+        'currency' => 'thb'
+    );
+    $charge = \OmisePlugin\Repository::create('OmiseCharge', $params);
+
+    if ($charge->need3DSecureProcess()) {
+        // redirect
+    } else {
+        // do nothing. Or maybe you can check,
+        // $charge->isPaid();
+    }
+    ```
+
+  - **validateAfter3DSecureProcess($success_callback, $fail_callback)**
+
+    **example**
+
+    ```php
+    // After buyer was redirected back by the 3-D Secure process.
+    // You can check the result by the following code.
+    $your_db_connection_object = DB::Connection();
+
     $charge = OmiseCharge::retrieve('chrg_id');
     $charge = \OmisePlugin\Repository::add($charge);
 
-    if ($charge->isPaid()) {
-        // success
-    } else {
-        // fail
-    }
+    $charge->validateAfter3DSecureProcess(
+        function($charge) use ($your_db_connection_object) {
+            // Update record as success.
+            // $your_db_connection_object->update('status', 'success');
+        },
+        function($charge) use ($your_db_connection_object) {
+            // Update record as failed.
+            // $your_db_connection_object->update('status', 'failed');
+        },
+    );
     ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Plugin for [Omise-PHP](http://github.com/omise/omise-php)
 
   - **create($params)**  
 
+    **return** `\OmiseCharge`
+
     **example**
 
     ```php
@@ -36,10 +38,12 @@ Plugin for [Omise-PHP](http://github.com/omise/omise-php)
 
   - **isAuthorized()**
 
+    **return** `bool`
+
     **example**
 
     ```php
-    $charge = \OmiseCharge::retrieve('chrg_id');
+    $charge = OmiseCharge::retrieve('chrg_id');
     $charge = \OmisePlugin\Repository::add($charge);
 
     if ($charge->isAuthorized()) {
@@ -49,7 +53,26 @@ Plugin for [Omise-PHP](http://github.com/omise/omise-php)
     }
     ```
 
+  - **isPaid()**
+
+    **return** `bool`
+
+    **example**
+
+    ```php
+    $charge = OmiseCharge::retrieve('chrg_id');
+    $charge = \OmisePlugin\Repository::add($charge);
+
+    if ($charge->isPaid()) {
+        // success
+    } else {
+        // fail
+    }
+    ```
+
   - **need3DSecureProcess()**
+
+    **return** `bool`
 
     **example**
 
@@ -70,6 +93,8 @@ Plugin for [Omise-PHP](http://github.com/omise/omise-php)
     ```
 
   - **validateAfter3DSecureProcess($success_callback, $fail_callback)**
+
+    **return** `mixed`
 
     **example**
 


### PR DESCRIPTION
### 1. 💬 Objective

Enhance OmiseChargeContext by adding
- need3DSecureProcess()
- validateAfter3DSecureProcess($success_callback, $fail_callback)

...

### 2. ⚙ What does the changes do? 

Check `README.md`

...

### 3. 🛡 Quality Assurance 

For `need3DSecureProcess()`,
- tested by create new charge with 3-D Secure enabled account and none-3-D Secure account.
- then test call `$charge->need3DSecureProcess();`

For `validateAfter3DSecureProcess()`,
- tested by try retrieve any charge and then,
- call - then test call `$charge->validateAfter3DSecureProcess();`
- you can test pass `success_callback` function or `fail_callback` function to check if it works.

...

### 4. 📝 Additional notes 

No.